### PR TITLE
ensure that the plugin is not run on dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,27 @@ Then inform rebar that you want this to be used as a plugin like so:
 
     {plugins, [rebar_vsn_plugin]}.
 
+Then add the semver version to the `<app-name>.app.src` file. It should go from something like
+
+    {application, rebar_vsn_plugin,
+       [{description, "Correct version manipulation for rebar"},
+        {vsn, git},
+        {modules, []},
+        {registered, []},
+        {applications, [kernel, stdlib]}]}.
+
+to this:
+
+    {application, rebar_vsn_plugin,
+       [{description, "Correct version manipulation for rebar"},
+        {vsn, semver},
+        {modules, []},
+        {registered, []},
+        {applications, [kernel, stdlib]}]}.
+
+The key change is the `{vsn, "semver"}` change. This tells the plugin
+that it needs to replace the version in this app with the tag + ref
+version it employs.
 
 Explanation
 -------------

--- a/src/rebar_vsn_plugin.erl
+++ b/src/rebar_vsn_plugin.erl
@@ -28,10 +28,20 @@
 %%============================================================================
 %% API
 %%============================================================================
-
 post_compile(Config, AppFile) ->
-    {ok, [{application, AppName, _}]} = file:consult(AppFile),
+    {ok, [{application, AppName, SrcDetail}]} = file:consult(AppFile),
+    case proplists:get_value(vsn, SrcDetail) of
+        semver ->
+            do_vsn_replacement(AppName, Config, AppFile);
+        _ ->
+            ok
+    end.
 
+%%============================================================================
+%% Internal Functions
+%%============================================================================
+
+do_vsn_replacement(AppName, Config, AppFile) ->
     EbinAppFile= filename:join("ebin", erlang:atom_to_list(AppName) ++ ".app"),
 
     {AppName, Details0} =


### PR DESCRIPTION
Right now in rebar plugins are expected to run on all apps in the
repo. That includes dependencies. There is no really easy way to get
around that. To avoid that the system now looks for a version of
"semver". In those that contain this tag we replace the version with a
good semver version.
