### PR TITLE
fix patch count calculation

### DIFF
--- a/src/rebar_vsn_plugin.erl
+++ b/src/rebar_vsn_plugin.erl
@@ -130,7 +130,7 @@ collect_default_refcount() ->
             undefined ->
                 os:cmd("git rev-list HEAD | wc -l");
             _ ->
-                get_patch_count(RawRef)
+                get_patch_count(Tag)
         end,
     {TagVsn, RawRef, RawCount}.
 


### PR DESCRIPTION
We originally calculated `RawRef..HEAD` what is wrong
since the RawRef IS the HEAD. We need to calculate
number of patches since the last known tag!
